### PR TITLE
Fix an issue with where clause with a dot character.

### DIFF
--- a/activerecord/lib/active_record/relation.rb
+++ b/activerecord/lib/active_record/relation.rb
@@ -529,9 +529,13 @@ module ActiveRecord
 
     def tables_in_string(string)
       return [] if string.blank?
+
+      # a condition value like 'any_thing.v4' will be treated as a table by the scan pattern
+      new = string.gsub(/('.*?')/, '')
+
       # always convert table names to downcase as in Oracle quoted table names are in uppercase
       # ignore raw_sql_ that is used by Oracle adapter as alias for limit/offset subqueries
-      string.scan(/([a-zA-Z_][.\w]+).?\./).flatten.map{ |s| s.downcase }.uniq - ['raw_sql_']
+      new.scan(/([a-zA-Z_][.\w]+).?\./).flatten.map{ |s| s.downcase }.uniq - ['raw_sql_']
     end
   end
 end

--- a/activerecord/test/cases/associations/eager_test.rb
+++ b/activerecord/test/cases/associations/eager_test.rb
@@ -857,6 +857,13 @@ class EagerAssociationTest < ActiveRecord::TestCase
     end
   end
 
+  def test_eager_with_dot_characters
+    assert_queries(2) do
+      # Before our fix, the dot character will be interpreted as table names and will cause this to run in one query
+      Comment.find :all, :conditions => "'my_comment.1' = 'my_comment.1'", :include => :post
+    end
+  end
+
   def test_preconfigured_includes_with_belongs_to
     author = posts(:welcome).author_with_posts
     assert_no_queries {assert_equal 5, author.posts.size}


### PR DESCRIPTION
```
 A SQL query with a condition value containing dot character causes join query based eager loading.
```

[Bug 1018392](https://bugzilla.redhat.com/show_bug.cgi?id=1018392)

Rails 3 has 2 approaches to avoid the N+1 queries problem. One involves creating a big join based query to pull in your associations, the other involves making a separate query per association.

When you call includes, rails decides which strategy to use. The default is to use the separate query approach unless it thinks you are referencing the columns from the associations in you conditions or order. Since that only works with the joins approach, it uses that instead.

Due to a bug in rails method tables_in_string, a SQL query that contains dot characters in the condition uses the join based query approach when the separate query approach is intended. 

The test cases in this commit are written to verify that the SQL query works as intended, specially with rails future release. 
