### PR TITLE
Not treating serialized field changes differently than other fields

### DIFF
--- a/activerecord/lib/active_record/attribute_methods/dirty.rb
+++ b/activerecord/lib/active_record/attribute_methods/dirty.rb
@@ -69,12 +69,16 @@ module ActiveRecord
 
       def update(*)
         if partial_updates?
-          # Serialized attributes should always be written in case they've been
-          # changed in place.
-          super(changed | (attributes.keys & self.class.serialized_attributes.keys))
+          super(keys_for_partial_write)
         else
           super
         end
+      end
+
+      # Serialized attributes should always be written in case they've been
+      # changed in place.
+      def keys_for_partial_write
+        changed | (attributes.keys & self.class.serialized_attributes.keys)
       end
 
       def _field_changed?(attr, old, value)


### PR DESCRIPTION
Working on getting a better change upstream into rails (active_record)

This only saves fields to the database that are marked as changed via: `field_will_change!` or `field=new_value`

NOTE:
Bundler isn't able to find arel 3.0.2 so I'm not able to run the tests.

ALSO:
I'm not sure if I have the pull request off of the correct branch. please double check this.
