### PR TITLE
Fix database retry connection issues

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -265,7 +265,7 @@ module ActiveRecord
 
       module Errors
         LOST_CONNECTION_EXCEPTIONS  = ['PGError']
-        LOST_CONNECTION_MESSAGES    = [/no connection to the server/, /FATAL:  terminating connection due to administrator command/, /closed connection/, /server closed the connection unexpectedly/, /not connected/, /socket not open/]
+        LOST_CONNECTION_MESSAGES    = [/no connection to the server/, /FATAL:  terminating connection due to administrator command/, /closed connection/, /server closed the connection unexpectedly/, /not connected/, /socket not open/, /connection not open/]
 
         def lost_connection_exceptions
           exceptions = LOST_CONNECTION_EXCEPTIONS
@@ -385,13 +385,12 @@ module ActiveRecord
             clear_cache!
             @connection.reset
             @open_transactions = 0
+            configure_connection
           rescue *lost_connection_exceptions => e
             if e.message =~ Regexp.union(*lost_connection_messages)
               @statements.send(:cache).clear
               connect
             end
-          else
-            configure_connection
           end
         end
         active?

--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -1325,7 +1325,7 @@ module ActiveRecord
         UNIQUE_VIOLATION      = "23505"
 
         def translate_exception(exception, message)
-          case exception.result.error_field(PGresult::PG_DIAG_SQLSTATE)
+          case exception.result.try(:error_field, PGresult::PG_DIAG_SQLSTATE)
           when UNIQUE_VIOLATION
             RecordNotUnique.new(message, exception)
           when FOREIGN_KEY_VIOLATION


### PR DESCRIPTION
Backport of the ["NoMethodError: undefined method `error_field' for nil:NilClass"](https://github.com/rails/rails/commit/be913c3964069fa9ff7c8a615e06705e3a6ec435) that fixes:
https://bugzilla.redhat.com/show_bug.cgi?id=1127789

Added a new PGError retryable connection message "connection not open" to fix:
https://bugzilla.redhat.com/show_bug.cgi?id=1120364

Both errors were recreated somewhat reliably by:
1. starting a rails console 
2. 100.times { User.first; sleep 0.1 }  # SomeModel.first
3. Then, restarting postgresql in another session.
