### PR TITLE
measure record instantiation time in AS::Notifications

### DIFF
--- a/activerecord/test/cases/associations/eager_test.rb
+++ b/activerecord/test/cases/associations/eager_test.rb
@@ -912,6 +912,42 @@ class EagerAssociationTest < ActiveRecord::TestCase
     end
   end
 
+  def test_association_loading_notification
+    notifications = messages_for('instantiation.active_record') do
+      Developer.all.merge!(:includes => 'projects', :where => { 'developers_projects.access_level' => 1 }, :limit => 5).to_a.size
+    end
+
+    message = notifications.first
+    payload = message.last
+    count = Developer.all.merge!(:includes => 'projects', :where => { 'developers_projects.access_level' => 1 }, :limit => 5).to_a.size
+
+    # eagerloaded row count should be greater than just developer count
+    assert_operator payload[:record_count], :>, count
+    assert_equal Developer.name, payload[:class_name]
+  end
+
+  def test_base_messages
+    notifications = messages_for('instantiation.active_record') do
+      Developer.all.to_a
+    end
+    message = notifications.first
+    payload = message.last
+
+    assert_equal Developer.all.to_a.count, payload[:record_count]
+    assert_equal Developer.name, payload[:class_name]
+  end
+
+  def messages_for(name)
+    notifications = []
+    ActiveSupport::Notifications.subscribe(name) do |*args|
+      notifications << args
+    end
+    yield
+    notifications
+  ensure
+    ActiveSupport::Notifications.unsubscribe(name)
+  end
+
   def test_load_with_sti_sharing_association
     assert_queries(2) do #should not do 1 query per subclass
       Comment.find :all, :include => :post


### PR DESCRIPTION
emit an event when we instantiate AR objects so we can see how manyrecords were instantiated and how long it took

backport of rails/rails@2a0d97bc89fc230241453cbbf55621309e1f3ac6
