### PR TITLE
fix broken backport :bomb:

### DIFF
--- a/activerecord/lib/active_record/associations/join_dependency.rb
+++ b/activerecord/lib/active_record/associations/join_dependency.rb
@@ -53,7 +53,7 @@ module ActiveRecord
 
         payload = {
           record_count: rows.length,
-          class_name: join_base.base_klass.name
+          class_name: join_base.active_record.name
         }
 
         message_bus.instrument('instantiation.active_record', payload) do

--- a/activerecord/test/cases/associations/eager_test.rb
+++ b/activerecord/test/cases/associations/eager_test.rb
@@ -914,12 +914,12 @@ class EagerAssociationTest < ActiveRecord::TestCase
 
   def test_association_loading_notification
     notifications = messages_for('instantiation.active_record') do
-      Developer.all.merge!(:includes => 'projects', :where => { 'developers_projects.access_level' => 1 }, :limit => 5).to_a.size
+      Developer.includes('projects').where({ 'developers_projects.access_level' => 1 }).limit(5).to_a.size
     end
 
     message = notifications.first
     payload = message.last
-    count = Developer.all.merge!(:includes => 'projects', :where => { 'developers_projects.access_level' => 1 }, :limit => 5).to_a.size
+    count = Developer.includes('projects').where({ 'developers_projects.access_level' => 1 }).limit(5).to_a.size
 
     # eagerloaded row count should be greater than just developer count
     assert_operator payload[:record_count], :>, count


### PR DESCRIPTION
The backport should have had these changes for 3.2.  Here they are now,
yay.
