### PR TITLE
Allow to specify a type for foreign key column in migrations

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,4 +1,18 @@
+*   Allow to specify a type for created foreign key column in `references` and
+    `add_reference` in migrations.
+
+    Example:
+
+        change_table :vehicle do |t|
+          t.references :station, type: :uuid
+        end
+
+    *Andrey Novikov & Łukasz Sarnacki*
+
 ## Rails 3.2.15 (Oct 16, 2013) ##
+
+*   `create_join_table` removes a common prefix when generating the join table.
+    This matches the existing behavior of HABTM associations.
 
 *   When calling the method .find_or_initialize_by_* from a collection_proxy
     it should set the inverse_of relation even when the entry was found on the db.

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
@@ -261,12 +261,21 @@ module ActiveRecord
         column(:updated_at, :datetime, options)
       end
 
+      # Adds an appropriately-named _id column as <tt>:integer</tt> (or whatever <tt>:type</tt> option specifies),
+      # plus a corresponding _type column if the <tt>:polymorphic</tt> option is supplied. If <tt>:polymorphic</tt>
+      # is a hash of options, these will be used when creating the <tt>_type</tt> column. The <tt>:index</tt> option
+      # will also create an index, similar to calling <tt>add_index</tt>.
+      #
+      #   references :tagger, polymorphic: true, index: true, type: :uuid
       def references(*args)
         options = args.extract_options!
         polymorphic = options.delete(:polymorphic)
+        index_options = options.delete(:index)
+        type = options.delete(:type) || :integer
         args.each do |col|
-          column("#{col}_id", :bigint, options)
-          column("#{col}_type", :string, polymorphic.is_a?(Hash) ? polymorphic : options) unless polymorphic.nil?
+          column("#{col}_id", type, options)
+          column("#{col}_type", :string, polymorphic.is_a?(Hash) ? polymorphic : options) if polymorphic
+          index(polymorphic ? %w(id type).map { |t| "#{col}_#{t}" } : "#{col}_id", index_options.is_a?(Hash) ? index_options : {}) if index_options
         end
       end
       alias :belongs_to :references

--- a/activerecord/test/cases/migration_test.rb
+++ b/activerecord/test/cases/migration_test.rb
@@ -1867,6 +1867,18 @@ if ActiveRecord::Base.connection.supports_migrations?
       end
     end
 
+    def test_references_column_type_with_polymorphic_and_type
+      with_change_table do |t|
+        t.references :taggable, polymorphic: true, type: :string
+      end
+    end
+
+    def test_remove_references_column_type_with_polymorphic_and_type
+      with_change_table do |t|
+        t.remove_references :taggable, polymorphic: true, type: :string
+      end
+    end
+
     def test_remove_references_column_type_with_polymorphic_removes_type
       with_change_table do |t|
         @connection.expects(:remove_column).with(:delete_me, 'taggable_type')


### PR DESCRIPTION
[Andrey Novikov & Łukasz Sarnacki]

This is a backport commit from master to support types in references calls in migrations.
