### PR TITLE
Backport disabling transactions in migrations

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,23 @@
+## Rails 4.0.0 (unreleased) ##
+
+*   Make it possible to execute migrations without a transaction even
+    if the database adapter supports DDL transactions.
+    Fixes #9483.
+
+    Example:
+
+        class ChangeEnum < ActiveRecord::Migration
+          self.disable_ddl_transaction!
+          def up
+            execute "ALTER TYPE model_size ADD VALUE 'new_value'"
+          end
+        end
+
+    *Yves Senn*
+
+*   Assigning "0.0" to a nullable numeric column does not make it dirty.
+    Fix #9034.
+
 *   Allow to specify a type for created foreign key column in `references` and
     `add_reference` in migrations.
 


### PR DESCRIPTION
Rails 4 has support for disabling transactions in migrations.  This is a backport of that commit.
