### PR TITLE
Backport explicit casting

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -1136,7 +1136,10 @@ module ActiveRecord
         clear_cache!
         quoted_table_name = quote_table_name(table_name)
 
-        execute "ALTER TABLE #{quoted_table_name} ALTER COLUMN #{quote_column_name(column_name)} TYPE #{type_to_sql(type, options[:limit], options[:precision], options[:scale])}"
+        sql_type = type_to_sql(type, options[:limit], options[:precision], options[:scale])
+        sql = "ALTER TABLE #{quoted_table_name} ALTER COLUMN #{quote_column_name(column_name)} TYPE #{sql_type}"
+        sql << " USING #{options[:using]}" if options[:using]
+        execute sql
 
         change_column_default(table_name, column_name, options[:default]) if options_include_default?(options)
         change_column_null(table_name, column_name, options[:null], options[:default]) if options.key?(:null)

--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -1139,6 +1139,9 @@ module ActiveRecord
         sql_type = type_to_sql(type, options[:limit], options[:precision], options[:scale])
         sql = "ALTER TABLE #{quoted_table_name} ALTER COLUMN #{quote_column_name(column_name)} TYPE #{sql_type}"
         sql << " USING #{options[:using]}" if options[:using]
+        if options[:cast_as]
+          sql << " USING CAST(#{quote_column_name(column_name)} AS #{type_to_sql(options[:cast_as], options[:limit], options[:precision], options[:scale])})"
+        end
         execute sql
 
         change_column_default(table_name, column_name, options[:default]) if options_include_default?(options)

--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -1131,37 +1131,12 @@ module ActiveRecord
         execute add_column_sql
       end
 
-      # Patch for Postgres 8.2.6 and migrations that require an implicit conversion (such as :string to :integer)
-      # https://rails.lighthouseapp.com/projects/8994-ruby-on-rails/tickets/1036
-      def using_cast(column_name, type, options)
-        return "" if postgresql_version < 80206
-        " USING CAST(#{quote_column_name(column_name)} AS #{type_to_sql(type, options[:limit], options[:precision], options[:scale])})"
-      end
-
       # Changes the column of a table.
       def change_column(table_name, column_name, type, options = {})
         clear_cache!
         quoted_table_name = quote_table_name(table_name)
 
-        begin
-          # Patch for Postgres 8.2.6 and migrations that require an implicit conversion (such as :string to :integer)
-          # https://rails.lighthouseapp.com/projects/8994-ruby-on-rails/tickets/1036
-          execute "ALTER TABLE #{quoted_table_name} ALTER COLUMN #{quote_column_name(column_name)} TYPE #{type_to_sql(type, options[:limit], options[:precision], options[:scale])}#{using_cast(column_name, type, options)}"
-        rescue ActiveRecord::StatementInvalid => e
-          raise e if postgresql_version > 80000
-          # This is PostgreSQL 7.x, so we have to use a more arcane way of doing it.
-          begin
-            begin_db_transaction
-            tmp_column_name = "#{column_name}_ar_tmp"
-            add_column(table_name, tmp_column_name, type, options)
-            execute "UPDATE #{quoted_table_name} SET #{quote_column_name(tmp_column_name)} = CAST(#{quote_column_name(column_name)} AS #{type_to_sql(type, options[:limit], options[:precision], options[:scale])})"
-            remove_column(table_name, column_name)
-            rename_column(table_name, tmp_column_name, column_name)
-            commit_db_transaction
-          rescue
-            rollback_db_transaction
-          end
-        end
+        execute "ALTER TABLE #{quoted_table_name} ALTER COLUMN #{quote_column_name(column_name)} TYPE #{type_to_sql(type, options[:limit], options[:precision], options[:scale])}"
 
         change_column_default(table_name, column_name, options[:default]) if options_include_default?(options)
         change_column_null(table_name, column_name, options[:null], options[:default]) if options.key?(:null)

--- a/activerecord/test/cases/adapters/postgresql/change_schema_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/change_schema_test.rb
@@ -21,6 +21,11 @@ module ActiveRecord
         connection.change_column :strings, :somedate, :timestamp, using: 'CAST("somedate" AS timestamp)'
         assert_equal :datetime, connection.columns(:strings).find { |c| c.name == 'somedate' }.type
       end
+
+      def test_change_type_with_symbol
+        connection.change_column :strings, :somedate, :timestamp, cast_as: :timestamp
+        assert_equal :datetime, connection.columns(:strings).find { |c| c.name == 'somedate' }.type
+      end
     end
   end
 end

--- a/activerecord/test/cases/adapters/postgresql/change_schema_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/change_schema_test.rb
@@ -19,6 +19,7 @@ module ActiveRecord
 
       def test_change_string_to_date
         connection.change_column :strings, :somedate, :timestamp, using: 'CAST("somedate" AS timestamp)'
+        assert_equal :datetime, connection.columns(:strings).find { |c| c.name == 'somedate' }.type
       end
     end
   end

--- a/activerecord/test/cases/adapters/postgresql/change_schema_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/change_schema_test.rb
@@ -1,0 +1,25 @@
+require 'cases/helper'
+
+module ActiveRecord
+  class Migration
+    class PGChangeSchemaTest < ActiveRecord::TestCase
+      attr_reader :connection
+
+      def setup
+        super
+        @connection = ActiveRecord::Base.connection
+        connection.create_table(:strings) do |t|
+          t.string :somedate
+        end
+      end
+
+      def teardown
+        connection.drop_table :strings
+      end
+
+      def test_change_string_to_date
+        connection.change_column :strings, :somedate, :timestamp, using: 'CAST("somedate" AS timestamp)'
+      end
+    end
+  end
+end


### PR DESCRIPTION
This backports explicit casting to `change_column` in migrations.
