### PR TITLE
active record currently accesses `Rails` module in 2 places without checks

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
@@ -275,7 +275,7 @@ module ActiveRecord
 
       protected
         def trim_message(msg)
-          Rails.env.production? ? (msg[0..1000] + "...") : msg
+          defined?(Rails.env) && Rails.env.production? ? (msg[0..1000] + "...") : msg
         end
 
         def log(sql, name = "SQL", binds = [])
@@ -303,7 +303,7 @@ module ActiveRecord
           $log.error("MIQ(abstract_adapter) Name: [#{name}], Message: [#{message}]") if $log
 
           # Return a generic message when in production to avoid exposing the contents of the SQL query to an end user
-          message = MIQ_STATEMENT_INVALID_MESSAGE if Rails.env.production?
+          message = MIQ_STATEMENT_INVALID_MESSAGE if defined?(Rails.env) && Rails.env.production?
 
           exception = translate_exception(e, message)
           exception.set_backtrace e.backtrace


### PR DESCRIPTION
This patches some code we added a while months back.
This is causing `fix_auth` to blowup.

https://bugzilla.redhat.com/show_bug.cgi?id=1217532

Alternative: I do have a fix that defines `Rails` for `fix_auth` (thanks @matthewd) , but wanted to make this fix here.

/cc @tenderlove @jrafanie @Fryguy
